### PR TITLE
Update rustc_version from 0.2 to 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ std = []
 cfg-if = "1.0.0"
 
 [build-dependencies]
-rustc_version = "0.2"
+rustc_version = "0.4"
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]


### PR DESCRIPTION
This doesn’t fix any particular known bugs; it just avoids unnecessarily using a really old version of this build dependency.