### PR TITLE
feat: enable loongarch64 LSX SIMD feature gate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(stdarch_loongarch)]
 //! A crate that provides support for half-precision 16-bit floating point
 //! types.
 //!


### PR DESCRIPTION
The loongarch64 LSX SIMD code already exists in
src/binary16/arch/loongarch64.rs and is properly gated behind cfg(target_arch = "loongarch64"), but building on loongarch64 with nightly Rust fails because the crate root is missing:

  #![feature(stdarch_loongarch)]

Without this, core::arch::loongarch64 intrinsics raise E0658 even on nightly, since stdarch_loongarch is still an unstable feature (Rust issue #117427).